### PR TITLE
now, I can erase and edit my new authors

### DIFF
--- a/api/authorData.js
+++ b/api/authorData.js
@@ -65,7 +65,7 @@ const updateAuthor = (payload) => new Promise((resolve, reject) => {
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify(payload) // Removed the semicolon here
+    body: JSON.stringify(payload)
   })
     .then((response) => response.json())
     .then((data) => resolve(data))

--- a/events/formEvents.js
+++ b/events/formEvents.js
@@ -27,13 +27,11 @@ const formEvents = () => {
       };
 
       createAuthor(payload)
-        .then((data) => {
-          console.warn(data);
-          return getAuthors(); // Call getAuthors after logging the data
-        })
-        .then(showAuthors)
-        .catch((error) => {
-          console.error('An error occurred:', error);
+        .then(({ name }) => {
+          const patchPayload = { firebaseKey: name };
+          updateAuthor(patchPayload).then(() => {
+            getAuthors().then(showAuthors);
+          });
         });
     }
 
@@ -54,4 +52,5 @@ const formEvents = () => {
     }
   });
 };
+
 export default formEvents;


### PR DESCRIPTION
I encountered an issue while trying to add a new author. I was facing difficulties as I was not including my Firebase key in the author object. Later, I realized that Firebase generates its own key and saves it as the name value. To resolve the issue, I first saved the 'name' value. Next, I updated the author object with a new payload that included my key values (FirebaseKey) and (name). Finally, I called the getAuthors function and displayed the authors on the DOM.